### PR TITLE
reload all sysctl parameters after removing app

### DIFF
--- a/scripts/remove
+++ b/scripts/remove
@@ -63,7 +63,7 @@ if [ -e "/etc/sysctl.d/90-inotify_minidlna.conf" ]; then
 	# Reload the kernel configuration.
 	if ! IS_PACKAGE_CHECK   # LXC doesn't allow sysctl to play with kernel options.
 	then
-		sysctl -p /etc/sysctl.d/90-inotify_minidlna.conf
+		sysctl --system
 	fi
 fi
 


### PR DESCRIPTION
## Problem

See #30 

## Solution

- Reload all sysctl parameters after removing /etc/sysctl.d/90-inotify_minidlna.conf

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
